### PR TITLE
fix regex error in clean_input

### DIFF
--- a/markov_demo/matrix_markov.py
+++ b/markov_demo/matrix_markov.py
@@ -106,7 +106,7 @@ class MatrixMarkov:
         about what such should be removed
         """
         input_text = re.sub(r'--', ' ', input_text)
-        input_text = re.sub('[\[].*?[\]]', '', input_text)
+        input_text = re.sub(r'[\[].*?[\]]', '', input_text)
         input_text = re.sub(r'(\b|\s+\-?|^\-?)(\d+|\d*\.\d+)\b','', input_text)
         return input_text
 


### PR DESCRIPTION
I didn't pick this up in local testing because of a python version mismatch (me: 3.11.3. remote: 3.12.2) 