### PR TITLE
improved (for wikipedia) text cleaning

### DIFF
--- a/markov_demo/clean_doc.py
+++ b/markov_demo/clean_doc.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+''' Example code to exercise the MatrixMarkov class '''
+import requests
+
+from numpy import random
+
+from matrix_markov import MatrixMarkov
+
+
+SOLR_QUERY_TIMEOUT = 180
+SOLR_URL = "http://20.84.107.89:8983/solr/"
+SOLR_QUERY = "nutch/select?fl=content%2Ctitle%2Curl&fq=url%3A%22https%3A%2F%2Fen.m.wikipedia.org*%22&indent=true&q.op=OR&q=Argon"
+STATIC_QUERY_STR = f"{SOLR_URL}{SOLR_QUERY}"
+
+response = requests.get(STATIC_QUERY_STR, timeout=SOLR_QUERY_TIMEOUT)
+docs_json = response.json()
+
+mm = MatrixMarkov()
+
+clean_text = mm.clean_input(docs_json['response']['docs'][0]['content'])
+print(clean_text)

--- a/markov_demo/load_docs.py
+++ b/markov_demo/load_docs.py
@@ -7,8 +7,13 @@ from numpy import random
 
 from matrix_markov import MatrixMarkov
 
+SOLR_QUERY_TIMEOUT = 180
+SOLR_URL = "http://20.84.107.89:8983/solr/"
+SOLR_QUERY = "nutch/select?fl=content%2Ctitle%2Curl&fq=url%3A%22https%3A%2F%2Fen.m.wikipedia.org*%22&indent=true&q.op=OR&q=Argon"
+STATIC_QUERY_STR = f"{SOLR_URL}{SOLR_QUERY}"
+
 response = requests.get(
-    "http://20.84.107.89:8983/solr/nutch/select?fl=url%2Ccontent&indent=true&q.op=OR&q=nutch",
+    STATIC_QUERY_STR,
     timeout=180)
 docs_json = response.json()
 


### PR DESCRIPTION
This iteratively removes text from the source material. 
First, regex substitution is used for inline text -- references like [12] will be removed, for example. 
Next, it does some kind of match against whole lines, and removes anything matching the criteria -- E.G., lines that are shorter than a certain length, or which contain a referency string (like ISBN or Bibcode).  

It's somewhat aggressive -- There's a higher emphasis on discarding meta-text than there is on retaining direct text. 