### PR TITLE
fix garbage collection when destroying a MatrixMarkov instance and rebuilding

### DIFF
--- a/markov_demo/matrix_markov.py
+++ b/markov_demo/matrix_markov.py
@@ -242,15 +242,6 @@ class MatrixMarkov:
             if val > 0:
                 print(f'idx: {idx}, val: {val}')
 
-    def reset_data_structures(self):
-        '''
-        Intended for cleaning old data
-        '''
-        self._counts = zeros(shape=(self._pad_size, self._pad_size))
-        self.transition_matx = matrix('0;0')
-        self.tuple_to_source_map = {}
-
-
 
 def main():  # pylint: disable=missing-function-docstring
     pass


### PR DESCRIPTION
Because Python's a GC language, `del` doesn't do anything for us until the garbage collector sweeps, and by default, that happens automatically.  

I've removed the `del` commands from the discord instance -- they weren't doing anything, because those chunks of memory will get picked up by the gc on its auto-sweep anyway (their ref-count goes to zero once we're out of scope of the function).  

I also removed the cleanup method from MatrixMarkov -- I tried to cleanup here, but there are some remaining references I couldn't get rid of. 

So instead, we: 
1. disable automatic garbage collection 
2. delete the _entire_ MatrixMarkov instance, forcing refcount for all of our big numpy arrays to 0
3. manually trigger GC to clean up the MatrixMarkov instance
4. re-enable automatic garbage collection.  

I also cleaned up a couple of inconsistent tabs in the file -- that's important for Python (everywhere else in this project we use tabstop = 4) 